### PR TITLE
Fix dir paths for vendor invariant

### DIFF
--- a/src/Load.php
+++ b/src/Load.php
@@ -89,12 +89,12 @@ abstract class Load
         $dirs =  array('');
         if (defined('K_PATH_FONTS')) {
             $dirs[] = K_PATH_FONTS;
-            $dirs = array_merge($dirs, array_filter(glob(K_PATH_FONTS.'/*'), 'is_dir'));
+            $dirs = array_merge($dirs, glob(K_PATH_FONTS.DIRECTORY_SEPARATOR.'*', GLOB_ONLYDIR));
         }
         $parent_font_dir = $dirobj->findParentDir('fonts', __DIR__);
         if (!empty($parent_font_dir)) {
             $dirs[] = $parent_font_dir;
-            $dirs = array_merge($dirs, array_filter(glob($parent_font_dir.'/*'), 'is_dir'));
+            $dirs = array_merge($dirs, glob($parent_font_dir.DIRECTORY_SEPARATOR.'*', GLOB_ONLYDIR));
         }
         return array_unique($dirs);
     }

--- a/src/Load.php
+++ b/src/Load.php
@@ -127,8 +127,8 @@ abstract class Load
 
         foreach ($files as $file) {
             foreach ($dirs as $dir) {
-                if (@is_readable($dir.$file)) {
-                    $this->data['ifile'] = $dir.$file;
+                if (@is_readable($dir.DIRECTORY_SEPARATOR.$file)) {
+                    $this->data['ifile'] = $dir.DIRECTORY_SEPARATOR.$file;
                     break 2;
                 }
             }

--- a/src/Load.php
+++ b/src/Load.php
@@ -39,7 +39,8 @@ abstract class Load
      */
     public function load()
     {
-        $this->data = array_merge($this->data, $this->getFontInfo());
+        $fontInfo = $this->getFontInfo();
+        $this->data = array_merge($this->data, $fontInfo);
         $this->checkType();
         $this->setName();
         $this->setDefaultWidth();

--- a/src/Load.php
+++ b/src/Load.php
@@ -130,6 +130,7 @@ abstract class Load
             foreach ($dirs as $dir) {
                 if (@is_readable($dir.DIRECTORY_SEPARATOR.$file)) {
                     $this->data['ifile'] = $dir.DIRECTORY_SEPARATOR.$file;
+                    $this->data['dir'] = $dir;
                     break 2;
                 }
             }

--- a/src/OutUtil.php
+++ b/src/OutUtil.php
@@ -52,8 +52,8 @@ abstract class OutUtil
             )
         );
         foreach ($dirs as $dir) {
-            if (@is_readable($dir.$file)) {
-                return $dir.$file;
+            if (@is_readable($dir.DIRECTORY_SEPARATOR.$file)) {
+                return $dir.DIRECTORY_SEPARATOR.$file;
             }
         }
         throw new FontException('Unable to locate the file: '.$file);


### PR DESCRIPTION
Method should not relay in '/' since it is Unix specific dir separator and file system root. DIRECTORY_SEPARATOR should be used instead.

Glob method can be used to filter directories only, no need to invoke is_dir method on each path.

Important is to notice that glob method does not add ending directory separator on Windows, so no font file can be found. I added additional directory separator in findFontFile method to secure such case. We can also adjust findFontDirectories in better way to provide ending directory separator for all paths.