### PR TITLE
Bump dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "ext-json": "*",
     "ext-pcre": "*",
     "ext-zlib": "*",
-    "tecnickcom/tc-lib-file": "^2.1",
+    "tecnickcom/tc-lib-file": "^2.1.4",
     "tecnickcom/tc-lib-unicode-data": "^2.0",
     "tecnickcom/tc-lib-pdf-encrypt": "^2.1"
   },


### PR DESCRIPTION
function `hasDoubleDots` was introduced in **2.1.4** https://github.com/tecnickcom/tc-lib-file/commit/fe2e2f4a23ab24b0f51468c5457027be1e2bc128

BTW, as this is a **new API**, this should probably have been released as **2.2.0**
