### PR TITLE
Possible perf improvement in Stack: stop re-resolving the font metric per character

### DIFF
--- a/src/Stack.php
+++ b/src/Stack.php
@@ -528,7 +528,12 @@ class Stack extends \Com\Tecnick\Pdf\Font\Buffer
             }
 
             $unitype = UnicodeType::UNI[$ord] ?? '';
-            $chrwidth = $this->getCharWidth($ord);
+            // Inline the width lookup using the already-resolved $curfont metric: calling
+            // getCharWidth() here would re-resolve getFontMetric($this->index) per character.
+            $chrwidth = match ($ord) {
+                173, 8203 => 0.0, // 173 = SHY (hyphenation), 8203 = ZWSP: not printed
+                default => $curfont['cwu'][$ord] ?? $curfont['cw'][$ord] ?? $curfont['dw'],
+            };
             // 'B' Paragraph Separator
             // 'S' Segment Separator
             // 'WS' Whitespace
@@ -615,7 +620,10 @@ class Stack extends \Com\Tecnick\Pdf\Font\Buffer
     protected function getFontMetric(int $idx): array
     {
         $font = $this->getStackItem($idx);
-        $mkey = \md5(\serialize($font));
+        // Cheap, collision-free cache key from just the fields the metric depends on,
+        // instead of md5(serialize($font)) which ran on every (mostly cache-hit) call.
+        $mkey = $font['key'] . '|' . $font['size'] . '|' . $font['spacing']
+            . '|' . $font['stretching'] . '|' . $font['style'];
         if (isset($this->metric[$mkey])) {
             return $this->metric[$mkey];
         }


### PR DESCRIPTION
I'm not 100% sure of the ramifications of changing the hash key from the current `md5(serialize($font))` which must run even for cache hits.  The proposed key seemed reasonably well thought out since the font conversion json files are based on font name and font style.

Heads up, this was diagnosed and authored by Claude.  The performance gains for me are very substantial. 

Fixes https://github.com/tecnickcom/tc-lib-pdf-font/issues/16.  All phpunit tests pass before and after on linux.

 - Hoist the width lookup: This deletes ~100k getCharWidth/getFontMetric/getStackItem/serialize/md5 calls outright.
 - getFontMetric still runs ~20k×, each doing md5(serialize()). Swap line for $mkey = $font['key'].'|'.$font['size'].'|'.$font['spacing'].'|'.$font['stretching'].'|'.$font['style'] — a string concat, no serialize/md5.

## Whole request: 7.14 s → **4.89 s (−31%)**

The entire Stack metric cluster collapsed exactly as predicted (absolute time, of the respective totals):

| function | calls before → after | self before | self after |
|---|---|---|---|
| `getFontMetric` | 120,424 → **20,549** | 0.69 s (9.68%) | **0.10 s** (1.99%) |
| `getCharWidth` | 103,775 → **850** | 0.51 s (7.21%) | **0.004 s** (0.08%) |
| `getStackItem` | 129,997 → 30,122 | 0.16 s | 0.04 s |
| `serialize` + `md5` | ~120k each → **0** | 0.13 s | **gone** |
| `getOrdArrDims` (self) | 3,050 | 0.67 s | 0.37 s |

That's **~1.5 s removed** from that cluster alone (the rest of the 2.25 s drop is cascaded call-overhead). `getFontMetric` now only fires from `getCurrentFont`/`insert`/`getOrdArrDims` (once each) — the per-character storm is gone.
...


## Checklist:

- [ ] The `make buildall` command has been run successfully without any error or warning.
- [ ] Any new code line is covered by unit tests and the coverage has not dropped.
- [ ] Any new code follows the style guidelines of this project.
- [X] The code changes have been self-reviewed.
- [ ] Corresponding changes to the documentation have been made.
- [ ] The version has been updated in the VERSION file.

## Type of change:
Performance.
